### PR TITLE
Amend the OMC role to handle the new omc/data repository checkout

### DIFF
--- a/QueryApp/bin/query.psgi
+++ b/QueryApp/bin/query.psgi
@@ -55,7 +55,7 @@ use OpenSSL::Query::DB;
 use URI::Encode qw(uri_decode);
 
 set serializer => 'JSON';
-set omc => '/var/cache/openssl/checkouts/omc';
+set data => '/var/cache/openssl/checkouts/data';
 
 # Version 0 API.
 # Feel free to add new routes, but never to change them or remove them,
@@ -73,7 +73,7 @@ sub name_decode {
 }
 
 get '/People' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc});
+  my $query = OpenSSL::Query->new(data => config->{data});
   my @response = $query->list_people();
 
   return [ @response ] if @response;
@@ -81,7 +81,7 @@ get '/People' => sub {
 };
 
 get '/Person/:name' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc});
+  my $query = OpenSSL::Query->new(data => config->{data});
   my $name = name_decode(uri_decode(param('name')));
   my %response = $query->find_person($name);
 
@@ -90,7 +90,7 @@ get '/Person/:name' => sub {
 };
 
 get '/Person/:name/Membership' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $query = OpenSSL::Query->new(data => config->{data}, REST => 0);
   my $name = name_decode(uri_decode(param('name')));
   my %response = $query->find_person($name);
 
@@ -99,7 +99,7 @@ get '/Person/:name/Membership' => sub {
 };
 
 get '/Person/:name/IsMemberOf/:group' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $query = OpenSSL::Query->new(data => config->{data}, REST => 0);
   my $name = name_decode(uri_decode(param('name')));
   my $group = uri_decode(param('group'));
   my $response = $query->is_member_of($name, $group);
@@ -109,7 +109,7 @@ get '/Person/:name/IsMemberOf/:group' => sub {
 };
 
 get '/Person/:name/ValueOfTag/:tag' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $query = OpenSSL::Query->new(data => config->{data}, REST => 0);
   my $name = name_decode(uri_decode(param('name')));
   my $tag = uri_decode(param('tag'));
   my $response = $query->find_person_tag($name, $tag);
@@ -119,7 +119,7 @@ get '/Person/:name/ValueOfTag/:tag' => sub {
 };
 
 get '/Person/:name/HasCLA' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $query = OpenSSL::Query->new(data => config->{data}, REST => 0);
   my $name = name_decode(uri_decode(param('name')));
   my %person = $query->find_person($name);
   my @response = ();
@@ -134,7 +134,7 @@ get '/Person/:name/HasCLA' => sub {
 };
 
 get '/Group/:group/Members' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $query = OpenSSL::Query->new(data => config->{data}, REST => 0);
   my $group = uri_decode(param('group'));
   my @response = $query->members_of($group);
 
@@ -143,7 +143,7 @@ get '/Group/:group/Members' => sub {
 };
 
 get '/Group/:group/CLAs' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $query = OpenSSL::Query->new(data => config->{data}, REST => 0);
   my $group = uri_decode(param('group'));
   my @response = ();
 
@@ -160,7 +160,7 @@ get '/Group/:group/CLAs' => sub {
 };
 
 get '/HasCLA/:id' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc}, REST => 0);
+  my $query = OpenSSL::Query->new(data => config->{data}, REST => 0);
   my $id = uri_decode(param('id'));
   if ($id =~ m|^\S+\@\S+$|) {
     my $response = $query->has_cla($id);
@@ -173,7 +173,7 @@ get '/HasCLA/:id' => sub {
 };
 
 get '/CLAs' => sub {
-  my $query = OpenSSL::Query->new(omc => config->{omc});
+  my $query = OpenSSL::Query->new(data => config->{data});
   my @response = $query->list_clas();
 
   return [ @response ] if @response;

--- a/QueryApp/lib/OpenSSL/Query/Role/OMC.pm
+++ b/QueryApp/lib/OpenSSL/Query/Role/OMC.pm
@@ -16,7 +16,8 @@ use Carp;
 use File::Spec::Functions;
 use Moo::Role;
 
-has omc => ( is => 'ro' );
+has data => ( is => 'ro' );
+has omc => ( is => 'ro' );	# Backward compat, data takes precedense
 has bureau => ( is => 'ro' );	# Backward compat, omc takes precedense
 
 sub _find_file {
@@ -24,9 +25,12 @@ sub _find_file {
   my $filename = shift;
   my $envvar = shift;
 
-  my $omc = $ENV{OMC} // $self->omc // $ENV{BUREAU} // $self->bureau;
+  my $data =
+      $ENV{DATA} // $self->data
+      // $ENV{OMC} // $self->omc
+      // $ENV{BUREAU} // $self->bureau;
   my @paths = ( $ENV{$envvar} // (),
-		$omc ? catfile($omc, $filename) : (),
+		$data ? catfile($data, $filename) : (),
 		catfile('.', $filename) );
   foreach (@paths) {
     return $_ if -r $_;


### PR DESCRIPTION
We also allow callers to refer to this option as 'data', but also
retain 'omc' and 'bureau' for backward compatibility.

The OMC role itself should also be renamed to DATA for consistency,
but that not strictly necessary to do now.

Fixes #2
