### PR TITLE
Ensure that premium support only versions end up in the proper place

### DIFF
--- a/archive-tools/do-release.pl
+++ b/archive-tools/do-release.pl
@@ -14,8 +14,40 @@ use File::Basename;
 my $homedir = glob("~openssl");
 my $tmpdir  = $ENV{"OPENSSL_TMP_DIR"} // $homedir . "/dist/new";
 my $olddir  = $ENV{"OPENSSL_OLD_DIR"} // $homedir . "/dist/old";
-my $ftpdir  = $ENV{"OPENSSL_FTP_DIR"} // "/srv/ftp/source";
 my $mail    = $ENV{"OPENSSL_MAIL"} // "mutt -s SUBJECT RECIP < BODY";
+
+my @public_series = qw( 3.0 1.1.1 );
+my @premium_series = qw( 1.0.2 );
+
+#
+# info takes the following arguments:
+#
+# - the series to be copied.
+#
+# It returns a HASH array with the following data:
+#
+# ftpdir => the path where the series should be stored
+# olddir => the path to move older releases into, or undef to not do that
+# annrecip => the list of recipients of the announcement email
+#
+sub info {
+    my $serie = shift;
+    my %info = (
+        ftpdir => $ENV{"OPENSSL_FTP_DIR"},
+        olddir => undef,
+    );
+
+    if ( grep { $serie eq $_ } @public_series ) {
+        $info{ftpdir} //= "/srv/ftp/source";
+        $info{olddir} = "$info{ftpdir}/old/$serie";
+        $info{annrecip} = "openssl-project openssl-users openssl-announce";
+    } elsif ( grep { $serie eq $_ } @premium_series ) {
+        $info{ftpdir} //= "/srv/premium";
+        $info{annrecip} = "premium-announce";
+    }
+
+    return %info;
+}
 
 my $do_mail   = 0;
 my $do_copy   = 0;
@@ -57,8 +89,7 @@ die "Can't find distribution directory $tmpdir"     unless -d $tmpdir;
 die "Can't find old distribution directory $olddir" unless -d $olddir;
 die "Can't find ftp directory $ftpdir"              unless -d $ftpdir;
 
-my @versions;
-my @series;
+my %versions;
 my @files = glob("$tmpdir/*.txt.asc");
 
 # VERSION, FULL_VERSION and PRE_RELEASE correspond to these macros from
@@ -87,51 +118,51 @@ my $basefile_re = qr/openssl-${version_re}/;
 
 foreach (@files) {
     if (m|^.*/${basefile_re}\Q.txt.asc\E$|) {
-        my $serie = $+{SERIES};
-        push @versions, $+{FULL_VERSION};
-        push @series, $serie unless grep /^${serie}$/, @series;
+        $versions{$+{FULL_VERSION}} = $+{SERIES};
     } else {
         die "Unexpected filename $_";
     }
 }
 
-die "No distribution in temp directory!" if ( scalar @versions == 0 );
+die "No distribution in temp directory!" if ( scalar %versions == 0 );
 print "OpenSSL versions to be released:\n";
-foreach (@versions) {
+foreach (sort keys %versions) {
     print "$_\n";
 }
 print "OK? (y/n)\n";
 $_ = <STDIN>;
 exit 1 unless /^y/i;
 
-my @distfiles;
-my @announce;
+my %distinfo;
 
-foreach (@versions) {
-    push @distfiles, "openssl-$_.tar.gz";
-    push @distfiles, "openssl-$_.tar.gz.sha1";
-    push @distfiles, "openssl-$_.tar.gz.sha256";
-    push @distfiles, "openssl-$_.tar.gz.asc";
-    push @announce,  "openssl-$_.txt.asc";
+foreach (sort keys %versions) {
+    %distinfo{$_} = { serie => $versions{$_},
+                      files => [ "openssl-$_.tar.gz",
+                                 "openssl-$_.tar.gz.sha1",
+                                 "openssl-$_.tar.gz.sha256",
+                                 "openssl-$_.tar.gz.asc" ] };
 }
 
 $do_copy = 0 if $mail_only;
 
 my $bad = 0;
 if ($do_copy) {
-    foreach (@distfiles) {
-        if ( !-f "$tmpdir/$_" ) {
-            print STDERR "File $_ not found in temp directory!\n";
-            $bad = 1;
-        }
-        if ( -e "$ftpdir/$_" ) {
-            print STDERR "File $_ already present in ftp directory!\n";
-            $bad = 1;
-        }
-        if ( -e "$olddir/$_" ) {
-            print STDERR
-              "File $_ already present in old distributions directory!\n";
-            $bad = 1;
+    foreach my $distinfo (sort keys %distinfo) {
+        my %info = info($distinfo->{serie});
+        foreach (@{$distinfo->{files}}) {
+            if ( !-f "$tmpdir/$_" ) {
+                print STDERR "File $_ not found in temp directory!\n";
+                $bad = 1;
+            }
+            if ( -e "$info{ftpdir}/$_" ) {
+                print STDERR "File $_ already present in ftp directory!\n";
+                $bad = 1;
+            }
+            if ( -e "$info{olddir}/$_" ) {
+                print STDERR
+                    "File $_ already present in old distributions directory!\n";
+                $bad = 1;
+            }
         }
     }
 }
@@ -140,10 +171,16 @@ exit 1 if $bad;
 
 print "Directory sanity check OK\n";
 
-print "Starting release for OpenSSL @versions\n";
+print "Starting release for OpenSSL ", join(' ', sort keys %versions), "\n";
 
 if ($do_copy) {
-    foreach my $serie (@series) {
+    my @series = ();
+    foreach my $distinfo (sort keys %distinfo) {
+        push @series, $distinfo->{serie}
+            unless grep { $_ eq $distinfo->{serie} } @series;
+    }
+
+    foreach my $serie (sort @series) {
         my @glob_patterns =
             $serie =~ m|^[01]\.|
             ? ( # pre-3.0 patterns
@@ -162,43 +199,49 @@ if ($do_copy) {
                "openssl-$serie.[0-9][0-9]-alpha[0-9].tar.gz",
                "openssl-$serie.[0-9][0-9]-beta[0-9].tar.gz",
               );
-        my $tomove_oldftp = "$ftpdir/old/$serie";
+        my %info = info($serie);
         my @tomove_ftp =
           map { basename ($_) }
           grep { -f $_ }
-          map { glob("$ftpdir/$_") }
+          map { glob("$info{ftpdir}/$_") }
           @glob_patterns;
 
-        mkdir $tomove_oldftp
-          or die "Couldn't mkdir $tomove_oldftp : $!"
-          if !-d $tomove_oldftp;
-        foreach (@tomove_ftp) {
-            print "DEBUG: mv $ftpdir/$_* $tomove_oldftp/\n" if $do_debug;
-            system("mv $ftpdir/$_* $tomove_oldftp/");
-            die "Error moving $_* to old ftp directory!" if $?;
+        if ($info{olddir}) {
+            mkdir $info{olddir}
+                or die "Couldn't mkdir $info{olddir} : $!"
+                if !-d $info{olddir};
+            foreach (@tomove_ftp) {
+                print "DEBUG: mv $info{ftpdir}/$_* $info{olddir}/\n" if $do_debug;
+                system("mv $info{ftpdir}/$_* $info{olddir}/");
+                die "Error moving $_* to old ftp directory!" if $?;
+            }
+            print
+                "Moved existing $serie distributions files to $info{olddir}\n";
         }
-        print
-            "Moved $serie distributions files to source/old and ftp/old directories\n";
     }
 
-    foreach (@distfiles) {
-        print "DEBUG: cp $tmpdir/$_ $ftpdir/$_\n" if $do_debug;
-        system("cp $tmpdir/$_ $ftpdir/$_");
-        die "Error copying $_ to ftp directory!" if $?;
+    foreach my $distinfo (sort keys %distinfo) {
+        my %info = info($distinfo->{serie});
+        foreach (@{$distinfo->{files}}) {
+            print "DEBUG: cp $tmpdir/$_ $info{ftpdir}/$_\n" if $do_debug;
+            system("cp $tmpdir/$_ $info{ftpdir}/$_");
+            die "Error copying $_ to ftp directory!" if $?;
+        }
+        print "Copied new $distinfo->{serie} distributions files to $info{ftpdir}\n";
     }
-    print "Copied distributions files to source and ftp directories\n";
-}
-else {
+} else {
     print "Test mode: no files copied\n";
 }
 
-foreach (@versions) {
+foreach (sort keys %versions) {
+    my %info = info($versions{$_});
     my $announce   = "openssl-$_.txt.asc";
     my $annversion = $_;
     $annversion =~ s/-pre(\d+$)/ pre release $1/;
     my $annmail = $mail;
+    my $annrecip = join(' ', @{$info{annrecip}});
     $annmail =~ s/SUBJECT/"OpenSSL version $annversion published"/;
-    $annmail =~ s/RECIP/openssl-project openssl-users openssl-announce/;
+    $annmail =~ s/RECIP/$annrecip/;
     $annmail =~ s|BODY|$tmpdir/$announce|;
 
     if ($do_mail) {
@@ -207,7 +250,7 @@ foreach (@versions) {
         system("$annmail");
         die "Error sending announcement email!" if $?;
         print "Don't forget to authorise the openssl-announce email.\n";
-        push @distfiles, $announce if $do_move;
+        push @{$distinfo{$_}->{files}}, $announce if $do_move;
     } else {
         print "Announcement email not sent automatically\n";
         print "\nSend announcement mail manually with command:\n\n$annmail\n\n";
@@ -218,9 +261,11 @@ foreach (@versions) {
 }
 
 if ($do_move) {
-    foreach (@distfiles) {
-        print "DEBUG: rename( '$tmpdir/$_', '$olddir/$_' )\n" if $do_debug;
-        rename( "$tmpdir/$_", "$olddir/$_" ) || die "Can't move $_: $!";
+    foreach my $distinfo (sort keys %distinfo) {
+        foreach (@{$distinfo->{files}}) {
+            print "DEBUG: rename( '$tmpdir/$_', '$olddir/$_' )\n" if $do_debug;
+            rename( "$tmpdir/$_", "$olddir/$_" ) || die "Can't move $_: $!";
+        }
     }
     print "Moved distribution files to old directory\n";
 }


### PR DESCRIPTION
1.0.2 releases aren't going to the public archives since 1.0.2v.
Getting it right required manual intervention since this script wasn't
updated.  Now it is, and we can conduct our 1.0.2 releases anew using
this script.

Doing this required quite a bit of changes, so we maintain a map of
versions <-> series, files <-> versions and series etc, to make sure
the correct directories and announcement mail addresses are affected
for each OpenSSL that's released.

This means that $ftpdir and @distfiles are gone, and are replaced with
the function info(), which returns appropriate information for the
given release series, and %distinfo, which is a comprehensive little
database of collected info that belong together.

^CT-141 Closed
