### PR TITLE
Add github-stats-tools

### DIFF
--- a/github-stat-tools/README.md
+++ b/github-stat-tools/README.md
@@ -1,0 +1,7 @@
+# Github stats tools
+
+## github-pending.py
+
+This script connects with the given github repository, finds out the amount
+of open PRs and issues, and feeds the amount to a chosen backend.  The
+backend will determine where that metric ends up.

--- a/github-stat-tools/github-pending.py
+++ b/github-stat-tools/github-pending.py
@@ -6,7 +6,7 @@ import requests
 import json
 import pprint
 from datetime import datetime, timezone
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 dryrun = False
 debug = False
@@ -69,33 +69,33 @@ backend = 'echo'
 git_token = ''
 
 # parse options
-parser = OptionParser()
+parser = ArgumentParser()
 
-parser.add_option('-b', '--backend',
-                  help='the output backend.  Accepted choices: echo, zabbix',
-                  dest='backend')
-parser.add_option('--host',
-                  help='the github host to check',
-                  dest='host')
-parser.add_option('-t', '--token',
-                  help='file containing github authentication token for example "18asdjada..."',
-                  dest='token')
-parser.add_option('-d', '--debug', action='store_true', help='be noisy',
-                  dest='debug')
-parser.add_option('-n', '--dry-run', action='store_true', help='be noisy',
-                  dest='dryrun')
+parser.add_argument('--backend', '-b',
+                    help='the output backend.  Accepted choices: echo, zabbix',
+                    dest='backend')
+parser.add_argument('--host',
+                    help='the github host to check',
+                    dest='host')
+parser.add_argument('--token', '-t',
+                    help='file containing github authentication token for example "18asdjada..."',
+                    dest='token')
+parser.add_argument('--debug', '-d', action='store_true', help='be noisy',
+                    dest='debug')
+parser.add_argument('--dry-run', '-n', action='store_true', help='be noisy',
+                    dest='dryrun')
 
-(options, args) = parser.parse_args()
+args = parser.parse_args()
 
-if options.backend:
-    backend = options.backend
-if options.host:
-    host = options.host
-if options.token:
-    fp = open(options.token, 'r')
+if args.backend:
+    backend = args.backend
+if args.host:
+    host = args.host
+if args.token:
+    fp = open(args.token, 'r')
     git_token = fp.readline().strip('\n')
-debug = options.debug
-dryrun = options.dryrun
+debug = args.debug
+dryrun = args.dryrun
 
 # info databases
 backends = {

--- a/github-stat-tools/github-pending.py
+++ b/github-stat-tools/github-pending.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 import sys
 import subprocess
@@ -87,17 +87,15 @@ parser.add_option('-n', '--dry-run', action='store_true', help='be noisy',
 
 (options, args) = parser.parse_args()
 
-if (options.backend):
+if options.backend:
     backend = options.backend
-if (options.host):
+if options.host:
     host = options.host
-if (options.token):
+if options.token:
     fp = open(options.token, 'r')
     git_token = fp.readline().strip('\n')
-if (options.debug):
-    debug = options.debug
-if (options.dryrun):
-    dryrun = options.dryrun
+debug = options.debug
+dryrun = options.dryrun
 
 # info databases
 backends = {

--- a/github-stat-tools/github-pending.py
+++ b/github-stat-tools/github-pending.py
@@ -1,0 +1,126 @@
+#! /usr/bin/python3
+
+import sys
+import subprocess
+import requests
+import json
+import pprint
+from datetime import datetime, timezone
+from optparse import OptionParser
+
+dryrun = False
+debug = False
+now = datetime.now(timezone.utc)
+
+### Helpers
+
+def search(host, q, headers):
+    search_urls = {
+        'github.com': 'https://api.github.com/search/issues'
+    }
+
+    url = search_urls[host] + '?q=' + '%20'.join(q)
+    if debug: print(f'DEBUG[search]: {url=}', file=sys.stderr)
+    res = requests.get(url, headers=headers).json()
+    if debug: print(f'DEBUG[search]: {res=}', file=sys.stderr)
+    return res
+
+### Result backends
+
+# Zabbix doesn't support much in terms of indexable <key:value>s alongside
+# the metric, like Prometheus or Loki do.  Instead, we feed all of them as
+# separate values in one input, with the hope that they all get the same
+# time stamp
+def backend_zabbix(host, basekey, values):
+    zabbix_command = ['zabbix_sender', '-z', 'm.openssl.org', '-i', '-']
+    zabbix_lines = [f'{host} {basekey}.{k} {v}' for k,v in values.items()]
+    zabbix_input = "\n".join(zabbix_lines) + "\n"
+    if debug or dryrun:
+        prefix = 'DEBUG[backend_zabbix]: ' if debug else ''
+        intro = 'would run this command:' if dryrun else 'running this command:'
+        for l in [ intro,
+                   '',
+                   ' '.join([ *zabbix_command, '<<_____']),
+                   *zabbix_lines,
+                   '_____',
+                   '' ]:
+            print(f'{prefix}{l}', file=sys.stderr)
+
+    if not dryrun:
+        subprocess.run(zabbix_command, input=zabbix_input, text=True);
+
+# Echoing is done in a way that's similar to Prometheus / Loki input.
+# The "metric" value is treated specially, so it becomes the actual sole
+# value, while the rest of the values are indexing label values.
+def backend_echo(host, basekey, values):
+    t = now.isoformat()
+    s = f'{basekey}' + '{' + ', '.join(
+        [ f'host="{host}"',
+          *( f'{k}="{v}"' for k,v in values.items() if k != 'metric' ) ]
+    ) + '}'
+    print(f'{t}: {s} {values["metric"]}')
+
+### Main
+
+# defaults
+host = 'github.com'
+backend = 'echo'
+# blank token is fine, but you may hit API rate limiting
+git_token = ''
+
+# parse options
+parser = OptionParser()
+
+parser.add_option('-b', '--backend',
+                  help='the output backend.  Accepted choices: echo, zabbix',
+                  dest='backend')
+parser.add_option('--host',
+                  help='the github host to check',
+                  dest='host')
+parser.add_option('-t', '--token',
+                  help='file containing github authentication token for example "18asdjada..."',
+                  dest='token')
+parser.add_option('-d', '--debug', action='store_true', help='be noisy',
+                  dest='debug')
+parser.add_option('-n', '--dry-run', action='store_true', help='be noisy',
+                  dest='dryrun')
+
+(options, args) = parser.parse_args()
+
+if (options.backend):
+    backend = options.backend
+if (options.host):
+    host = options.host
+if (options.token):
+    fp = open(options.token, 'r')
+    git_token = fp.readline().strip('\n')
+if (options.debug):
+    debug = options.debug
+if (options.dryrun):
+    dryrun = options.dryrun
+
+# info databases
+backends = {
+    'zabbix': backend_zabbix,
+    'echo': backend_echo,
+}
+
+headers = {
+    'Accept': 'application/vnd.github+json',
+    'Authorization': git_token,
+}
+
+# Do stuff
+open_issues = search(
+    host, [ 'repo:openssl/openssl', 'type:issue', 'state:open' ], headers
+)
+open_pulls = search(
+    host, [ 'repo:openssl/openssl', 'type:pr', 'state:open' ], headers
+)
+
+backends[backend](host, 'openssl.issues.gap',
+                  { 'repo': 'openssl/openssl',
+                    'metric': open_issues['total_count'] })
+backends[backend](host, 'openssl.prs.gap',
+                  { 'repo': 'openssl/openssl',
+                    'metric': open_pulls['total_count'] })

--- a/github-stat-tools/github-pending.py
+++ b/github-stat-tools/github-pending.py
@@ -60,6 +60,13 @@ def backend_echo(host, basekey, values):
     ) + '}'
     print(f'{t}: {s} {values["metric"]}')
 
+### Info databases
+
+backends = {
+    'zabbix': backend_zabbix,
+    'echo': backend_echo,
+}
+
 ### Main
 
 # defaults
@@ -72,8 +79,8 @@ git_token = ''
 parser = ArgumentParser()
 
 parser.add_argument('--backend', '-b',
-                    help='the output backend.  Accepted choices: echo, zabbix',
-                    dest='backend')
+                    help=f'the output backend.  Accepted choices: {", ".join(sorted(list(backends)))}',
+                    dest='backend', choices=list(backends))
 parser.add_argument('--host',
                     help='the github host to check',
                     dest='host')
@@ -97,18 +104,13 @@ if args.token:
 debug = args.debug
 dryrun = args.dryrun
 
-# info databases
-backends = {
-    'zabbix': backend_zabbix,
-    'echo': backend_echo,
-}
-
+# Do stuff
 headers = {
     'Accept': 'application/vnd.github+json',
     'Authorization': git_token,
 }
 
-# Do stuff
+
 open_issues = search(
     host, [ 'repo:openssl/openssl', 'type:issue', 'state:open' ], headers
 )


### PR DESCRIPTION
This is intended as a directory for multiple scripts that pull diverse stats
from github.

The first script is `github-pending.py`, which simply gets the current
amount of open PRs and issues and produces metric samples from that, with
different possible output backends.  This script should be run at regular
intervals, thus producing a timeline of our progress in dealing with PRs and
issues.

It's not yet determined where these data are going to be collected.  There's
a tentative backend to feed a zabbix server, experience will show if that
works as intended or if some other collector would be more suitable.
